### PR TITLE
make s2i scripts readable as well as executable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ LABEL io.k8s.description="Run SOLR search in OpenShift" \
       io.openshift.s2i.scripts-url="image:///${STI_SCRIPTS_PATH}"
 
 COPY ./s2i/bin/. ${STI_SCRIPTS_PATH}
-RUN chmod -R a+x ${STI_SCRIPTS_PATH}
+RUN chmod -R a+rx ${STI_SCRIPTS_PATH}
 
 # If we need to add files as part of every SOLR conf, they'd go here
 # COPY ./solr-config/ /tmp/solr-config


### PR DESCRIPTION
This minor change was necessary in order to build a solr container in our Docker environment